### PR TITLE
Update seqtk_mergefa.xml

### DIFF
--- a/tools/seqtk/seqtk_mergefa.xml
+++ b/tools/seqtk/seqtk_mergefa.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <tool id="seqtk_mergefa" name="seqtk_mergefa" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="22.05">
-    <description>merge two FASTA/Q files</description>
+    <description>Merge two FASTA files</description>
     <macros>
         <import>macros.xml</import>
     </macros>
@@ -16,14 +16,14 @@ $r
 $h
 '$in_fa1'
 '$in_fa2'
-#echo "| pigz -p ${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fa1.is_of_type('fasta.gz', 'fastq.gz') else "" # > '$default'
+#echo "| pigz -p ${GALAXY_SLOTS:-1} --no-name --no-time" if $in_fa1.is_of_type('fasta.gz') else "" # > '$default'
     ]]></command>
     <inputs>
-        <param name="in_fa1" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #1"/>
-        <param name="in_fa2" type="data" format="fasta,fastq,fasta.gz,fastq.gz" label="Input FASTA/Q file #2"/>
+        <param name="in_fa1" type="data" format="fasta,fasta.gz" label="Input FASTA file #1"/>
+        <param name="in_fa2" type="data" format="fasta,fasta.gz" label="Input FASTA file #2"/>
         <param argument="-q" type="integer" value="0" label="Quality threshold"/>
         <param argument="-i" type="boolean" truevalue="-i" falsevalue="" checked="false" label="Take intersection" />
-        <param argument="-m" type="boolean" truevalue="-m" falsevalue="" checked="false" label="Convert to lowercase when one of the input base is N" />
+        <param argument="-m" type="boolean" truevalue="-m" falsevalue="" checked="false" label="Convert to lowercase when one of the input bases is N" />
         <param argument="-r" type="boolean" truevalue="-r" falsevalue="" checked="false" label="Pick a random allele from het" />
         <param argument="-h" type="boolean" truevalue="-h" falsevalue="" checked="false" label="Suppress hets in the input" />
     </inputs>
@@ -52,7 +52,7 @@ $h
     <help><![CDATA[
 **What it does**
 
-Merges two fasta files, using ambiguity codes
+Merges two FASTA files using ambiguity codes.
 
 ::
 


### PR DESCRIPTION
- Restricted input formats to only FASTA and compressed FASTA files (.fasta, .fasta.gz). Removed support for FASTQ files.
- Updated the tool description and help section to accurately reflect that the tool only merges FASTA files.
- Improved the tool's clarity by ensuring it is used for its intended purpose: merging FASTA files only.

FOR CONTRIBUTOR:
* [x] I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
* [x] License permits unrestricted use (educational + commercial)
* [x] This PR adds a new tool or tool collection
* [x] This PR updates an existing tool or tool collection
* [x] This PR does something else (explain below)
